### PR TITLE
fixes: bouncer cannot be found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,9 @@
                 <version>0.0.3</version>
                 <configuration>
                     <mainClass>HelloFX</mainClass>
+                    <options>
+                      <option>--add-opens javafx.base/com.sun.javafx.reflect=ALL-UNNAMED</option>
+                    </options>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fixes error -  

```
Exception in thread "JavaFX Application Thread" java.lang.InternalError: bouncer cannot be found
.....
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make private static java.lang.Object com.sun.javafx.reflect.Trampoline.invoke(java.lang.reflect.Method,java.lang.Object,java.lang.Object[]) throws java.lang.reflect.InvocationTargetException,java.lang.IllegalAccessException accessible: module javafx.base does not "opens com.sun.javafx.reflect" to unnamed module @737547fa
...
```